### PR TITLE
Add ability to disable judging for LLM envs

### DIFF
--- a/umshini/example_client.py
+++ b/umshini/example_client.py
@@ -8,7 +8,7 @@ from colorama import Fore, Style
 from .tournament_client import TournamentConnection
 
 
-class ColosseumTournamentAgent:
+class UmshiniTournamentAgent:
     def __init__(
         self,
         policy,
@@ -51,7 +51,12 @@ class ColosseumTournamentAgent:
                 + f"Bot: {self.botname}'s policy has passed environment verifications"
             )
             print(Style.RESET_ALL)
-        except Exception:
+        except Exception as e:
+            if self.debug:
+                print(
+                    Fore.RED
+                    + f"ERROR: {e}"
+                )
             print(
                 Fore.RED
                 + f"Bot: {self.botname}'s policy has failed verification testing in environment: {self.games}"

--- a/umshini/learner.py
+++ b/umshini/learner.py
@@ -2,12 +2,12 @@
 
 from colorama import Fore, Style
 
-from .example_client import ColosseumTournamentAgent
+from .example_client import UmshiniTournamentAgent
 from .tournament_client import TestEnv
 
 
 def create_and_run(botname, user_key):
-    agent = ColosseumTournamentAgent(maximum_rounds=100)
+    agent = UmshiniTournamentAgent(maximum_rounds=100)
     agent.connect(botname, user_key)
     agent.run()
 
@@ -21,7 +21,7 @@ def connect(environment, botname, user_key, user_policy, debug=False, testing=Fa
     Passed function returns action
     """
     if testing:
-        agent = ColosseumTournamentAgent(
+        agent = UmshiniTournamentAgent(
             policy=user_policy,
             games=[environment],
             maximum_rounds=100,
@@ -30,7 +30,7 @@ def connect(environment, botname, user_key, user_policy, debug=False, testing=Fa
             debug=debug,
         )
     else:
-        agent = ColosseumTournamentAgent(
+        agent = UmshiniTournamentAgent(
             policy=user_policy,
             games=[environment],
             maximum_rounds=100,

--- a/umshini/tournament_client.py
+++ b/umshini/tournament_client.py
@@ -160,7 +160,7 @@ class NetworkEnv(gym.Env):
 class TestEnv(gym.Env):
     def __init__(self, env_id):
         seed = 1
-        self.env, self.turn_based = make_test_env(env_id, seed=seed)
+        self.env, self.turn_based = make_test_env(env_id, seed=seed, debug=True)
         self.env.reset()
         self.agent = agent = self.env.agents[0]
         self.observation_space = self.env.observation_space(agent)
@@ -233,7 +233,7 @@ class TestEnv(gym.Env):
 class TestAECEnv(gym.Env):
     def __init__(self, env_id):
         seed = 1
-        self.env = make_test_env(env_id, seed=seed)
+        self.env = make_test_env(env_id, seed=seed, debug=True)
         self.env.reset()
         self.agent = agent = self.env.agents[0]
         self.observation_space = self.env.observation_spaces[agent]


### PR DESCRIPTION
This prevents users from being charged/having to have openai keys when the client verifies the LLM envs locally before the tournament