### PR TITLE
Remove all parallel conversion code (use AEC envs internally)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 classic = ["pettingzoo[classic]>=1.24.0"]
-llm = ["chatarena[umshini]>=0.1.12.10"]
-all = ["pettingzoo[classic]>=1.24.0", "chatarena[umshini]>=0.1.12.10"]
+llm = ["chatarena[umshini] @ git+https://github.com/Farama-Foundation/chatarena.git@dev"]
+all = ["pettingzoo[classic]>=1.24.0", "chatarena[umshini] @ git+https://github.com/Farama-Foundation/chatarena.git@dev"]
 testing = [ "pytest", "pytest-cov" ]
 
 [tool.setuptools.dynamic]

--- a/tests/test_umshini_client.py
+++ b/tests/test_umshini_client.py
@@ -1,4 +1,5 @@
 from multiprocessing import Pool
+from typing import Callable
 
 import numpy as np
 
@@ -16,19 +17,26 @@ def rand_policy(obs, rew, term, trunc, info):
     return (action, 0)
 
 
-def run_player(env, botname, userkey, policy):
+def run_player(
+    env_name: str, botname: str, userkey: str, policy: Callable, testing: bool
+):
     umshini.connect(
-        env,
+        env_name,
         botname,
         userkey,
         policy,
-        debug=True,
-        testing=True,
+        debug=testing,
+        testing=testing,
     )
 
 
-def test_umshini_client(env_name):
-    num_players = 4
+def test_umshini_client(
+    env_name: str = "connect_four_v3", num_players: int = 4, testing: bool = True
+):
+    assert isinstance(num_players, int)
+    assert isinstance(testing, bool)
+    if num_players is None:
+        num_players = 4
     env_to_id = {
         "go_v5": 1,
         "connect_four_v3": 2,
@@ -40,7 +48,7 @@ def test_umshini_client(env_name):
     env_id = env_to_id[env_name]
     args = []
     for i in range(1, 1 + num_players):
-        args.append((env_name, f"user{i}_{env_id}", f"user{i}", rand_policy))
+        args.append((env_name, f"user{i}_{env_id}", f"user{i}", rand_policy, testing))
 
     with Pool(num_players) as pool:
         pool.starmap(run_player, args)

--- a/umshini/envs/envs_list.py
+++ b/umshini/envs/envs_list.py
@@ -1,8 +1,6 @@
 import os
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 
-from pettingzoo.utils import aec_to_parallel, turn_based_aec_to_parallel
-
 
 @contextmanager
 def suppress_stdout_stderr():
@@ -84,16 +82,10 @@ def import_llm(env_name, render_mode):
 def make_test_env(env_id, seed=None, render_mode=None, debug=False):
     env = make_env(env_id, render_mode, debug)
 
-    turn_based = not env.metadata["is_parallelizable"]
-    if turn_based:
-        env = turn_based_aec_to_parallel(env)
-    else:
-        env = aec_to_parallel(env)
-
     # seed can only be set using env.reset
     env.reset(seed)
 
-    return env, turn_based
+    return env
 
 
 def make_env(env_id, render_mode=None, debug=False):

--- a/umshini/example_client.py
+++ b/umshini/example_client.py
@@ -114,14 +114,10 @@ class UmshiniTournamentAgent:
             term = False
             trunc = False
             timestep = 0
-            rew = info = None
-            initial_obs = env.reset()
-            if initial_obs is None:
-                # handling edge case of environment automatically resetting (e.g. opp instantly folds in Texas Holdem)
-                term = True
-                obs = None
-            else:
-                obs, info = initial_obs
+            rew = None
+            env.reset()
+            obs, info = env.last()
+
             while not (term or trunc):
                 if timestep % 100 == 0 and self.debug:
                     print(f"{self.botname}: Timestep {timestep}\n")

--- a/umshini/example_client.py
+++ b/umshini/example_client.py
@@ -129,9 +129,8 @@ class UmshiniTournamentAgent:
                 action_surprise = self.policy(
                     obs, rew, term, trunc, info
                 )  # receive action and surprise from user
-                obs, rew, term, trunc, info = env.step(
-                    action_surprise
-                )  # Send action to game server
+                env.step(action_surprise)  # Send action to game server
+                obs, rew, term, trunc, info = env.last()
                 timestep += 1
             print(Fore.GREEN + f"Round {current_round} complete")
             print(Style.RESET_ALL)

--- a/umshini/examples/example_agent.py
+++ b/umshini/examples/example_agent.py
@@ -22,7 +22,7 @@ from umshini.envs.envs_list import make_test_env
 class DummyAgent:
     def __init__(self, env_name):
         self.env_name = env_name
-        self.env, _ = make_test_env(env_name, seed=1)
+        self.env = make_test_env(env_name, seed=1)
         self.env.reset()
 
     def pol(self, obs, rew, term, trunc, info):

--- a/umshini/learner.py
+++ b/umshini/learner.py
@@ -54,8 +54,7 @@ def test(env_id: str, user_policy: callable | None = None):
     for _ in range(100):
         try:
             (action, surprise) = user_policy(obs, rew, term, trunc, info)
-            test_env.step(action)
-            obs, rew, term, trunc, info = test_env.last()
+            obs, rew, term, trunc, info = test_env.step(action)
 
             if term or trunc:
                 print(

--- a/umshini/learner.py
+++ b/umshini/learner.py
@@ -54,7 +54,8 @@ def test(env_id: str, user_policy: callable | None = None):
     for _ in range(100):
         try:
             (action, surprise) = user_policy(obs, rew, term, trunc, info)
-            obs, rew, term, trunc, info = test_env.step(action)
+            test_env.step(action)
+            obs, rew, term, trunc, info = test_env.last()
 
             if term or trunc:
                 print(

--- a/umshini/tournament_client.py
+++ b/umshini/tournament_client.py
@@ -180,7 +180,6 @@ class TestEnv(gym.Env):
         self.num_steps = 0
         self.was_term = False
         self.was_trunc = False
-        self.obss = None
 
     def reset(self, **kwargs):
         self.num_steps = 0

--- a/umshini/tournament_client.py
+++ b/umshini/tournament_client.py
@@ -185,10 +185,8 @@ class TestEnv(gym.Env):
         self.num_steps = 0
         self.was_term = False
         self.was_trunc = False
-        self.env.reset()
-
-    def last(self, observe: bool = True):
-        return self.env.last(observe)
+        obss, info = self.env.reset()
+        return obss, info
 
     def step(self, action):
         assert (
@@ -212,6 +210,8 @@ class TestEnv(gym.Env):
         # Update underlying AEC env (for last() to work)
         self.env.terminations[self.agent] = term
         self.env.truncations[self.agent] = trunc
+
+        return obs, rew, term, trunc, info
 
     def render(self, mode="human"):
         return
@@ -244,8 +244,7 @@ class TournamentConnection:
     def _test_environments(self):
         for game in self.available_games:
             test_env = TestEnv(game)
-            test_env.reset()
-            obs, _, term, trunc, _ = test_env.last()
+            obs, info = test_env.reset()
             for i in range(100):
                 if (
                     obs is not None
@@ -256,8 +255,7 @@ class TournamentConnection:
                     action = np.random.choice(obs["action_mask"].nonzero()[0])
                 else:
                     action = test_env.action_space.sample()
-                test_env.step(action)
-                obs, _, term, trunc, _ = test_env.last()
+                obs, _, term, trunc, _ = test_env.step(action)
                 if term or trunc:
                     if self.debug:
                         print(f"{self.botname} passed test in {game}")

--- a/umshini/tournament_client.py
+++ b/umshini/tournament_client.py
@@ -185,8 +185,7 @@ class TestEnv(gym.Env):
         self.num_steps = 0
         self.was_term = False
         self.was_trunc = False
-        obss, info = self.env.reset()
-        return obss, info
+        self.env.reset()
 
     def last(self, observe: bool = True):
         return self.env.last(observe)
@@ -245,7 +244,8 @@ class TournamentConnection:
     def _test_environments(self):
         for game in self.available_games:
             test_env = TestEnv(game)
-            obs, info = test_env.reset()
+            test_env.reset()
+            obs, _, term, trunc, _ = test_env.last()
             for i in range(100):
                 if (
                     obs is not None

--- a/umshini/tournament_client.py
+++ b/umshini/tournament_client.py
@@ -44,7 +44,7 @@ class NetworkEnv(gym.Env):
             return
 
         # Create env for initial action and observation spaces
-        self.env, self.turn_based = make_test_env(env_id, seed=seed)
+        self.env = make_test_env(env_id, seed=seed)
         if self.verbose > 1:
             print("Game server data:", self.game_data)
         self.agent = (
@@ -172,7 +172,7 @@ class NetworkEnv(gym.Env):
 class TestEnv(gym.Env):
     def __init__(self, env_id):
         seed = 1
-        self.env, self.turn_based = make_test_env(env_id, seed=seed, debug=True)
+        self.env = make_test_env(env_id, seed=seed, debug=True)
         self.env.reset()
         self.agent = agent = self.env.agents[0]
         self.observation_space = self.env.observation_space(agent)


### PR DESCRIPTION
In the server code it actually was handled with AEC environments already, but this just cleans things up and makes it much more readable and obvious as to how to locally test yourself. The parallel code was remaining from a year ago or so when doing Atari environments.