### PR TITLE
Update dependencies and remove optional extras (simplify installation)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,3 @@
-# pyproject.toml
-
 include = [
     "umshini/**",
 ]
@@ -28,23 +26,24 @@ dependencies = [
     "numpy>=1.19.0",
     "pettingzoo>=1.24.0",
     "gymnasium>=0.28.0",
-    "halo",
-    "colorama",
+    "halo==0.0.31",
+    "colorama==0.4.6",
+    "chess==1.9.4",
+    "rlcard==1.0.5",
+    "pygame==2.3.0",
+    "chatarena[umshini]>=0.1.17"
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
-rl = ["pettingzoo>=1.24.0", "chess==1.9.4", "rlcard==1.0.5", "pygame==2.3.0"]
-llm = ["chatarena[umshini]>=0.1.12.10"]
-all = ["pettingzoo>=1.24.0", "chess==1.9.4", "rlcard==1.0.5", "pygame==2.3.0", "chatarena[umshini]>=0.1.12.10"]
 testing = [ "pytest", "pytest-cov", "deptry" ]
 
 [tool.setuptools.dynamic]
 version = {attr = "umshini.__version__"}
 
 [project.urls]
-Repository = "https://github.com/Umshini/Umshini-Server/"
-"Bug Report" = "https://github.com/Umshini/Umshini-Server/issues"
+Repository = "https://github.com/Umshini/Umshini-Client/"
+"Bug Report" = "https://github.com/Umshini/Umshini-Client/issues"
 
 [tool.pytest.ini_options]
 addopts = [ "--cov=umshini", "--cov-branch", "--cov-context=test", "--cov-report=html", "--cov-report=term-missing", "--ignore=tests/test_umshini_client.py", "--ignore=tests/test_local_game.py", "--ignore-glob=*/__init__.py"]


### PR DESCRIPTION
This is based off feedback we've recieved about it being confusing that you have to do pip install umshini[rl] or umshini[llm] (mainly was a holdover from gymnasium/pettingzoo which you want to be able to install only the package and none of the environments, but umshini doesn't really make sense to use without any environments). 

Will go through and update the documentation accordingly, which will simplify things as well.