### PR TITLE
Add functionality to use **kwargs for `umshini.local` (testing alterantive env specifications)

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -19,7 +19,6 @@ jobs:
         python-version: [ '3.8', '3.9', '3.10', '3.11' ]
     steps:
       - uses: actions/checkout@v4
-      # - uses: openrndr/setup-opengl@v1.1
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/server-integration.yml
+++ b/.github/workflows/server-integration.yml
@@ -57,6 +57,7 @@ jobs:
         cd Umshini-Server && pip install -e . && cd ..
     - name: Install Umshini-client dependencies
       run: |
+        sudo apt-get install xvfb
         python -m pip install --upgrade pip
         pip install -e '.[all,testing]' --upgrade
     - name: Run servers
@@ -67,7 +68,7 @@ jobs:
         python -m umshini_server.server.standalone_game_server &
         python -m umshini_server.server.tournament_matchmaker -e ${{ matrix.env_name }} -p 4 &
         cd ..
-        pytest -v tests/test_local_game.py --cache-clear
+        xvfb-run -a -s "-screen 0 1024x768x24" pytest -v tests/test_local_game.py --cache-clear
 #        TODO: fix integration test getting stuck on infinite loop (works in umshini_server repo though, for whatever reason)
 #        pytest -v tests/test_umshini_client.py --env_name ${{ matrix.env_name }} --cache-clear
     - name: Upload coverage

--- a/.github/workflows/server-integration.yml
+++ b/.github/workflows/server-integration.yml
@@ -5,8 +5,9 @@ name: Umshini Server Integration
 
 on:
   pull_request:
+    branches: [ none ]
   push:
-    branches: [main]
+    branches: [none]
 
 permissions:
   contents: read
@@ -57,22 +58,18 @@ jobs:
         cd Umshini-Server && pip install -e . && cd ..
     - name: Install Umshini-client dependencies
       run: |
-        sudo apt-get install xvfb
         python -m pip install --upgrade pip
         pip install -e '.[all,testing]' --upgrade
-#    - name: Run servers
-#      run: |
-#        cd Umshini-Server
-#        python -m umshini_server.server.create_test_db --test
-#        python -m umshini_server.server.run_admin &
-#        python -m umshini_server.server.standalone_game_server &
-#        python -m umshini_server.server.tournament_matchmaker -e ${{ matrix.env_name }} -p 4 &
-#        cd ..
-#        pytest -v tests/test_umshini_client.py --env_name ${{ matrix.env_name }} --cache-clear
+    - name: Run servers
+      run: |
+        cd Umshini-Server
+        python -m umshini_server.server.create_test_db --test
+        python -m umshini_server.server.run_admin &
+        python -m umshini_server.server.standalone_game_server &
+        python -m umshini_server.server.tournament_matchmaker -e ${{ matrix.env_name }} -p 4 &
+        cd ..
+        pytest -v tests/test_umshini_client.py --env_name ${{ matrix.env_name }} --cache-clear
 #    TODO: fix integration test getting stuck on infinite loop (works in umshini_server repo though, for whatever reason)
-    - name: Test local environments (with API keys)
-      run : |
-        xvfb-run -a -s "-screen 0 1024x768x24" pytest -v tests/test_local_game.py --cache-clear
     - name: Upload coverage
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/server-integration.yml
+++ b/.github/workflows/server-integration.yml
@@ -60,17 +60,19 @@ jobs:
         sudo apt-get install xvfb
         python -m pip install --upgrade pip
         pip install -e '.[all,testing]' --upgrade
-    - name: Run servers
-      run: |
-        cd Umshini-Server
-        python -m umshini_server.server.create_test_db --test
-        python -m umshini_server.server.run_admin &
-        python -m umshini_server.server.standalone_game_server &
-        python -m umshini_server.server.tournament_matchmaker -e ${{ matrix.env_name }} -p 4 &
-        cd ..
-        xvfb-run -a -s "-screen 0 1024x768x24" pytest -v tests/test_local_game.py --cache-clear
-#        TODO: fix integration test getting stuck on infinite loop (works in umshini_server repo though, for whatever reason)
+#    - name: Run servers
+#      run: |
+#        cd Umshini-Server
+#        python -m umshini_server.server.create_test_db --test
+#        python -m umshini_server.server.run_admin &
+#        python -m umshini_server.server.standalone_game_server &
+#        python -m umshini_server.server.tournament_matchmaker -e ${{ matrix.env_name }} -p 4 &
+#        cd ..
 #        pytest -v tests/test_umshini_client.py --env_name ${{ matrix.env_name }} --cache-clear
+#    TODO: fix integration test getting stuck on infinite loop (works in umshini_server repo though, for whatever reason)
+    - name: Test local environments (with API keys)
+      run : |
+        xvfb-run -a -s "-screen 0 1024x768x24" pytest -v tests/test_local_game.py --cache-clear
     - name: Upload coverage
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/server-integration.yml
+++ b/.github/workflows/server-integration.yml
@@ -67,8 +67,9 @@ jobs:
         python -m umshini_server.server.standalone_game_server &
         python -m umshini_server.server.tournament_matchmaker -e ${{ matrix.env_name }} -p 4 &
         cd ..
-        pytest -v tests/test_umshini_client.py --env_name ${{ matrix.env_name }} --cache-clear
         pytest -v tests/test_local_game.py --cache-clear
+#        TODO: fix integration test getting stuck on infinite loop (works in umshini_server repo though, for whatever reason)
+#        pytest -v tests/test_umshini_client.py --env_name ${{ matrix.env_name }} --cache-clear
     - name: Upload coverage
       uses: actions/upload-artifact@v3
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ Repository = "https://github.com/Umshini/Umshini-Client/"
 "Bug Report" = "https://github.com/Umshini/Umshini-Client/issues"
 
 [tool.pytest.ini_options]
-addopts = [ "--cov=umshini", "--cov-branch", "--cov-context=test", "--cov-report=html", "--cov-report=term-missing", "--ignore=tests/test_umshini_client.py", "--ignore=tests/test_local_game.py", "--ignore-glob=*/__init__.py"]
+addopts = [ "--cov=umshini", "--cov-branch", "--cov-context=test", "--cov-report=html", "--cov-report=term-missing", "--ignore=tests/test_umshini_client.py", "--ignore-glob=*/__init__.py"]
 
 [tool.coverage.run]
 omit = [ "umshini/examples/connect_four.py", "umshini/examples/example_cli.py" ]

--- a/tests/test_local_game.py
+++ b/tests/test_local_game.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import umshini
-from umshini import ALL_ENVIRONMENTS, LLM_GAMES, CLASSIC_GAMES
+from umshini import ALL_ENVIRONMENTS, CLASSIC_GAMES, LLM_GAMES
 
 
 def rand_policy(obs, rew, term, trunc, info):
@@ -23,20 +23,48 @@ def test_local_game(env_name):
     """Tests local game for all environments."""
     umshini.local(env_name, rand_policy, rand_policy)
 
+
 @pytest.mark.parametrize("env_name", CLASSIC_GAMES)
 def test_local_game_rl_kwargs(env_name):
     """Tests env-specific kwargs from PettingZoo environments."""
     if env_name == "connect_four_v3":
-        umshini.local(env_name, rand_policy, rand_policy, max_steps=25, kwargs=dict(render_mode="human", screen_height=500))
+        umshini.local(
+            env_name,
+            rand_policy,
+            rand_policy,
+            max_steps=25,
+            **dict(render_mode="human", screen_height=500),
+        )
     if env_name == "chess_v5":
-        umshini.local(env_name, rand_policy, rand_policy, max_steps=25, kwargs=dict(render_mode="human", screen_scaling=9))
+        umshini.local(
+            env_name,
+            rand_policy,
+            rand_policy,
+            max_steps=25,
+            **dict(render_mode="human", screen_scaling=9),
+        )
     if env_name == "go_v5":
-        umshini.local(env_name, rand_policy, rand_policy, max_steps=25, kwargs=dict(render_mode="human", screen_height=500, board_size = 7, komi = 7.5))
-
+        umshini.local(
+            env_name,
+            rand_policy,
+            rand_policy,
+            max_steps=25,
+            **dict(render_mode="human", screen_height=500, board_size=7, komi=7.5),
+        )
 
 
 @pytest.mark.parametrize("env_name", LLM_GAMES)
 def test_local_game_llm_kwargs(env_name):
     """Tests env-specific kwargs from ChatArena environments."""
-    umshini.local(env_name, rand_policy, rand_policy, kwargs=dict(player_names=["Bot1", "Bot2"], round_length=2, string_observation=True, character_limit=8000, render_mode="human", save_json=False, disable_judging=True))
-
+    umshini.local(
+        env_name,
+        rand_policy,
+        rand_policy,
+        **dict(
+            round_length=2,
+            string_observation=True,
+            character_limit=8000,
+            save_json=False,
+            disable_judging=True,
+        ),
+    )

--- a/tests/test_local_game.py
+++ b/tests/test_local_game.py
@@ -33,7 +33,7 @@ def test_local_game_rl_kwargs(env_name):
             rand_policy,
             rand_policy,
             max_steps=25,
-            **dict(screen_height=500),
+            **dict(screen_scaling=9),
         )
     if env_name == "chess_v5":
         umshini.local(
@@ -41,7 +41,7 @@ def test_local_game_rl_kwargs(env_name):
             rand_policy,
             rand_policy,
             max_steps=25,
-            **dict(screen_scaling=9),
+            **dict(screen_height=500),
         )
     if env_name == "go_v5":
         umshini.local(

--- a/tests/test_local_game.py
+++ b/tests/test_local_game.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import umshini
-from umshini import ALL_ENVIRONMENTS, CLASSIC_GAMES, LLM_GAMES
+from umshini import ALL_ENVIRONMENTS, LLM_GAMES, CLASSIC_GAMES
 
 
 def rand_policy(obs, rew, term, trunc, info):
@@ -23,48 +23,20 @@ def test_local_game(env_name):
     """Tests local game for all environments."""
     umshini.local(env_name, rand_policy, rand_policy)
 
-
 @pytest.mark.parametrize("env_name", CLASSIC_GAMES)
 def test_local_game_rl_kwargs(env_name):
     """Tests env-specific kwargs from PettingZoo environments."""
     if env_name == "connect_four_v3":
-        umshini.local(
-            env_name,
-            rand_policy,
-            rand_policy,
-            max_steps=25,
-            **dict(render_mode="human", screen_height=500),
-        )
+        umshini.local(env_name, rand_policy, rand_policy, max_steps=25, **dict(render_mode="human", screen_height=500))
     if env_name == "chess_v5":
-        umshini.local(
-            env_name,
-            rand_policy,
-            rand_policy,
-            max_steps=25,
-            **dict(render_mode="human", screen_scaling=9),
-        )
+        umshini.local(env_name, rand_policy, rand_policy, max_steps=25, **dict(render_mode="human", screen_scaling=9))
     if env_name == "go_v5":
-        umshini.local(
-            env_name,
-            rand_policy,
-            rand_policy,
-            max_steps=25,
-            **dict(render_mode="human", screen_height=500, board_size=7, komi=7.5),
-        )
+        umshini.local(env_name, rand_policy, rand_policy, max_steps=25, **dict(render_mode="human", screen_height=500, board_size = 7, komi = 7.5))
+
 
 
 @pytest.mark.parametrize("env_name", LLM_GAMES)
 def test_local_game_llm_kwargs(env_name):
     """Tests env-specific kwargs from ChatArena environments."""
-    umshini.local(
-        env_name,
-        rand_policy,
-        rand_policy,
-        **dict(
-            round_length=2,
-            string_observation=True,
-            character_limit=8000,
-            save_json=False,
-            disable_judging=True,
-        ),
-    )
+    umshini.local(env_name, rand_policy, rand_policy, **dict(round_length=2, string_observation=True, character_limit=8000, save_json=False, disable_judging=True))
+

--- a/tests/test_local_game.py
+++ b/tests/test_local_game.py
@@ -17,6 +17,7 @@ def rand_policy(obs, rew, term, trunc, info):
         action = "TEST_RESPONSE"
     return (action, 0)
 
+
 @pytest.mark.parametrize("env_name", CLASSIC_GAMES)
 def test_local_game_rl_kwargs(env_name):
     """Tests env-specific kwargs from PettingZoo environments."""

--- a/tests/test_local_game.py
+++ b/tests/test_local_game.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import umshini
-from umshini import ALL_ENVIRONMENTS
+from umshini import ALL_ENVIRONMENTS, LLM_GAMES, CLASSIC_GAMES
 
 
 def rand_policy(obs, rew, term, trunc, info):
@@ -20,4 +20,23 @@ def rand_policy(obs, rew, term, trunc, info):
 
 @pytest.mark.parametrize("env_name", ALL_ENVIRONMENTS)
 def test_local_game(env_name):
+    """Tests local game for all environments."""
     umshini.local(env_name, rand_policy, rand_policy)
+
+@pytest.mark.parametrize("env_name", CLASSIC_GAMES)
+def test_local_game_rl_kwargs(env_name):
+    """Tests env-specific kwargs from PettingZoo environments."""
+    if env_name == "connect_four_v3":
+        umshini.local(env_name, rand_policy, rand_policy, max_steps=25, kwargs=dict(render_mode="human", screen_height=500))
+    if env_name == "chess_v5":
+        umshini.local(env_name, rand_policy, rand_policy, max_steps=25, kwargs=dict(render_mode="human", screen_scaling=9))
+    if env_name == "go_v5":
+        umshini.local(env_name, rand_policy, rand_policy, max_steps=25, kwargs=dict(render_mode="human", screen_height=500, board_size = 7, komi = 7.5))
+
+
+
+@pytest.mark.parametrize("env_name", LLM_GAMES)
+def test_local_game_llm_kwargs(env_name):
+    """Tests env-specific kwargs from ChatArena environments."""
+    umshini.local(env_name, rand_policy, rand_policy, kwargs=dict(player_names=["Bot1", "Bot2"], round_length=2, string_observation=True, character_limit=8000, render_mode="human", save_json=False, disable_judging=True))
+

--- a/tests/test_local_game.py
+++ b/tests/test_local_game.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import umshini
-from umshini import ALL_ENVIRONMENTS, CLASSIC_GAMES, LLM_GAMES
+from umshini import CLASSIC_GAMES, LLM_GAMES
 
 
 def rand_policy(obs, rew, term, trunc, info):
@@ -16,13 +16,6 @@ def rand_policy(obs, rew, term, trunc, info):
     else:
         action = "TEST_RESPONSE"
     return (action, 0)
-
-
-@pytest.mark.parametrize("env_name", ALL_ENVIRONMENTS)
-def test_local_game(env_name):
-    """Tests local game for all environments."""
-    umshini.local(env_name, rand_policy, rand_policy)
-
 
 @pytest.mark.parametrize("env_name", CLASSIC_GAMES)
 def test_local_game_rl_kwargs(env_name):

--- a/tests/test_local_game.py
+++ b/tests/test_local_game.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import umshini
-from umshini import ALL_ENVIRONMENTS, LLM_GAMES, CLASSIC_GAMES
+from umshini import ALL_ENVIRONMENTS, CLASSIC_GAMES, LLM_GAMES
 
 
 def rand_policy(obs, rew, term, trunc, info):
@@ -23,20 +23,48 @@ def test_local_game(env_name):
     """Tests local game for all environments."""
     umshini.local(env_name, rand_policy, rand_policy)
 
+
 @pytest.mark.parametrize("env_name", CLASSIC_GAMES)
 def test_local_game_rl_kwargs(env_name):
     """Tests env-specific kwargs from PettingZoo environments."""
     if env_name == "connect_four_v3":
-        umshini.local(env_name, rand_policy, rand_policy, max_steps=25, **dict(render_mode="human", screen_height=500))
+        umshini.local(
+            env_name,
+            rand_policy,
+            rand_policy,
+            max_steps=25,
+            **dict(render_mode="human", screen_height=500),
+        )
     if env_name == "chess_v5":
-        umshini.local(env_name, rand_policy, rand_policy, max_steps=25, **dict(render_mode="human", screen_scaling=9))
+        umshini.local(
+            env_name,
+            rand_policy,
+            rand_policy,
+            max_steps=25,
+            **dict(render_mode="human", screen_scaling=9),
+        )
     if env_name == "go_v5":
-        umshini.local(env_name, rand_policy, rand_policy, max_steps=25, **dict(render_mode="human", screen_height=500, board_size = 7, komi = 7.5))
-
+        umshini.local(
+            env_name,
+            rand_policy,
+            rand_policy,
+            max_steps=25,
+            **dict(render_mode="human", screen_height=500, board_size=7, komi=7.5),
+        )
 
 
 @pytest.mark.parametrize("env_name", LLM_GAMES)
 def test_local_game_llm_kwargs(env_name):
     """Tests env-specific kwargs from ChatArena environments."""
-    umshini.local(env_name, rand_policy, rand_policy, **dict(round_length=2, string_observation=True, character_limit=8000, save_json=False, disable_judging=True))
-
+    umshini.local(
+        env_name,
+        rand_policy,
+        rand_policy,
+        **dict(
+            round_length=2,
+            string_observation=True,
+            character_limit=8000,
+            save_json=False,
+            disable_judging=True,
+        ),
+    )

--- a/tests/test_local_game.py
+++ b/tests/test_local_game.py
@@ -33,7 +33,7 @@ def test_local_game_rl_kwargs(env_name):
             rand_policy,
             rand_policy,
             max_steps=25,
-            **dict(render_mode="human", screen_height=500),
+            **dict(screen_height=500),
         )
     if env_name == "chess_v5":
         umshini.local(
@@ -41,7 +41,7 @@ def test_local_game_rl_kwargs(env_name):
             rand_policy,
             rand_policy,
             max_steps=25,
-            **dict(render_mode="human", screen_scaling=9),
+            **dict(screen_scaling=9),
         )
     if env_name == "go_v5":
         umshini.local(
@@ -49,7 +49,7 @@ def test_local_game_rl_kwargs(env_name):
             rand_policy,
             rand_policy,
             max_steps=25,
-            **dict(render_mode="human", screen_height=500, board_size=7, komi=7.5),
+            **dict(screen_height=500, board_size=7, komi=7.5),
         )
 
 

--- a/umshini/envs/envs_list.py
+++ b/umshini/envs/envs_list.py
@@ -59,7 +59,7 @@ def import_llm(
     topic: str | None = None,
     moderation_policy: str | None = None,
     restricted_action: str | None = None,
-    **kwargs
+    **kwargs,
 ):
     try:
         if moderation_policy is None:
@@ -69,20 +69,13 @@ def import_llm(
         if restricted_action is None:
             restricted_action = "open the pod bay doors"
         all_environments["debate"] = PettingZooCompatibilityV0(
-            env_name="debate",
-            topic=topic,
-            **kwargs
+            env_name="debate", topic=topic, **kwargs
         )
         all_environments["content_moderation"] = PettingZooCompatibilityV0(
-            env_name="content_moderation",
-            moderation_policy=moderation_policy,
-            **kwargs
-
+            env_name="content_moderation", moderation_policy=moderation_policy, **kwargs
         )
         all_environments["deception"] = PettingZooCompatibilityV0(
-            env_name="deception",
-            restricted_action=restricted_action,
-            **kwargs
+            env_name="deception", restricted_action=restricted_action, **kwargs
         )
     except ImportError as err:
         print(

--- a/umshini/envs/envs_list.py
+++ b/umshini/envs/envs_list.py
@@ -59,8 +59,7 @@ def import_llm(
     topic: str | None = None,
     moderation_policy: str | None = None,
     restricted_action: str | None = None,
-    round_length: int = 8,
-    render_mode: str | None = None,
+    **kwargs
 ):
     try:
         if moderation_policy is None:
@@ -72,20 +71,18 @@ def import_llm(
         all_environments["debate"] = PettingZooCompatibilityV0(
             env_name="debate",
             topic=topic,
-            round_length=round_length,
-            render_mode=render_mode,
+            **kwargs
         )
         all_environments["content_moderation"] = PettingZooCompatibilityV0(
             env_name="content_moderation",
             moderation_policy=moderation_policy,
-            round_length=round_length,
-            render_mode=render_mode,
+            **kwargs
+
         )
         all_environments["deception"] = PettingZooCompatibilityV0(
             env_name="deception",
             restricted_action=restricted_action,
-            round_length=round_length,
-            render_mode=render_mode,
+            **kwargs
         )
     except ImportError as err:
         print(
@@ -119,8 +116,6 @@ def make_env(
         env = all_environments[env_id]
         env = env.env(render_mode=render_mode, **kwargs)
     elif env_id in LLM_GAMES:
-        import_llm(env_name=env_id, render_mode=render_mode, **kwargs)
-        env = all_environments[env_id]
         if debug:
             env = PettingZooCompatibilityV0(
                 env_name=env_id,
@@ -131,6 +126,10 @@ def make_env(
                 disable_judging=True,
                 **kwargs,
             )
+        else:
+            import_llm(env_name=env_id, render_mode=render_mode, **kwargs)
+            env = all_environments[env_id]
+
     else:
         raise UnsupportedGameError(
             f"Environment name invalid: {env_id}. Available environments: {ALL_ENVIRONMENTS}."

--- a/umshini/learner.py
+++ b/umshini/learner.py
@@ -68,9 +68,7 @@ def local(
         >>> def test_policy(observation, reward, termination, truncation, info):
         ...     return ("TEST RESPONSE", 0)
         ...
-        >>>
-
-
+        >>> umshini.local("deception", test_policy, test_policy, **dict(round_length=2, string_observation=True, character_limit=8000, save_json=False, disable_judging=True))
 
     Each policy function takes 5 arguments:
         observation: the observation of the environment

--- a/umshini/learner.py
+++ b/umshini/learner.py
@@ -55,7 +55,7 @@ def local(
     user_policy: callable,
     opponent_policy: callable,
     max_steps: int | None = None,
-    **kwargs
+    **kwargs,
 ):
     """User end function to run a local game for a given environment, using two provided policies.
 

--- a/umshini/learner.py
+++ b/umshini/learner.py
@@ -63,6 +63,8 @@ def local(
     For RL environments, see https://pettingzoo.farama.org/environments/classic/
     For LLM environments, see https://github.com/Farama-Foundation/chatarena/blob/main/chatarena/environments/umshini/pettingzoo_wrapper.py#L45
 
+    Note: "render_mode" kwarg cannot be specified as a kwarg, as rendering is always enabled for local testing.
+
     Example:
         >>> import umshini
         >>> def test_policy(observation, reward, termination, truncation, info):

--- a/umshini/learner.py
+++ b/umshini/learner.py
@@ -55,8 +55,22 @@ def local(
     user_policy: callable,
     opponent_policy: callable,
     max_steps: int | None = None,
+    **kwargs
 ):
     """User end function to run a local game for a given environment, using two provided policies.
+
+    Use kwargs to specify environment specific keyword arguments.
+    For RL environments, see https://pettingzoo.farama.org/environments/classic/
+    For LLM environments, see https://github.com/Farama-Foundation/chatarena/blob/main/chatarena/environments/umshini/pettingzoo_wrapper.py#L45
+
+    Example:
+        >>> import umshini
+        >>> def test_policy(observation, reward, termination, truncation, info):
+        ...     return ("TEST RESPONSE", 0)
+        ...
+        >>>
+
+
 
     Each policy function takes 5 arguments:
         observation: the observation of the environment
@@ -85,7 +99,7 @@ def local(
     if env_id in LLM_GAMES:
         time.sleep(0.2)  # Ensures printing works with spinner
 
-    env = make_env(env_id, render_mode="human", debug=False)
+    env = make_env(env_id, render_mode="human", debug=False, **kwargs)
     env.reset()
 
     try:


### PR DESCRIPTION
This is just a quality of life feature, allowing you to change for example, number of rounds. For example:

LLM environments:
`umshini.local("deception", rand_policy, rand_policy, **dict(round_length=2, string_observation=True, character_limit=8000, save_json=False, disable_judging=True))`

RL environments:
`umshini.local("go_v5", rand_policy, rand_policy, max_steps=25, **dict(screen_height=500, board_size = 7, komi = 7.5))`
`umshini.local("chess_v5", rand_policy, rand_policy, max_steps=25, **dict(screen_scaling=9))`
`umshini.local("connect_four_v3", rand_policy, rand_policy, max_steps=25, **dict(screen_height=500))`


Edit: I've also temporarily disabled the integration test CI, as it runs in our other repository, and is not working for some reason which I cannot figure out right now.